### PR TITLE
Pyhton is missing during the cdk deploy

### DIFF
--- a/dockerAssets.d/Dockerfile
+++ b/dockerAssets.d/Dockerfile
@@ -5,6 +5,7 @@ ENV KUBECONFIG /home/kubectl/.kube/kubeconfig
 ENV HOME /home/kubectl
 # ENV KUBECONFIG /root/.kube/kubeconfig
 
+RUN apk add --no-cache curl jq python3 py3-pip 
 
 RUN \
 	mkdir /root/bin /aws; \


### PR DESCRIPTION
When I execute `cdk deploy` command, the following error occurs:

```
Step 4/9 : RUN  mkdir /root/bin /aws;   apk -Uuv add groff less bash python py-pip jq curl docker &&    pip install --upgrade pip;      pip install awscli &&   apk --purge -v del py-pip &&    rm /var/cache/apk/* &&  adduser kubectl -Du 5566
 ---> Running in d7877c38ac45
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  python (missing):
    required by: world[python]
/bin/sh: pip: not found
The command '/bin/sh -c mkdir /root/bin /aws;   apk -Uuv add groff less bash python py-pip jq curl docker &&    pip install --upgrade pip;      pip install awscli &&   apk --purge -v del py-pip &&    rm /var/cache/apk/* &&  adduser kubectl -Du 5566' returned a non-zero code: 127
[100%] fail: docker build --tag cdkasset-c04b22ebdc150054f38e18491fc9cc6aafc77411b4a7db45672fe85c2f1b6dfa . exited with error code 127: The command '/bin/sh -c mkdir /root/bin /aws;   apk -Uuv add groff less bash python py-pip jq curl docker &&    pip install --upgrade pip;       pip install awscli &&   apk --purge -v del py-pip &&    rm /var/cache/apk/* &&  adduser kubectl -Du 5566' returned a non-zero code: 127

   CdkStackALBEksBg failed: Error: Failed to publish one or more assets. See the error messages above for more information.
Failed to publish one or more assets. See the error messages above for more information.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
