### PR TITLE
Update Kubectl to 1.22.6 in Dockerfile

### DIFF
--- a/dockerAssets.d/Dockerfile
+++ b/dockerAssets.d/Dockerfile
@@ -15,7 +15,7 @@ RUN \
 	# Create non-root user (with a randomly chosen UID/GUI).
 	adduser kubectl -Du 5566
 
-ADD https://amazon-eks.s3-us-west-2.amazonaws.com/1.14.6/2019-08-22/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 #COPY kubectl /usr/local/bin/kubectl
 
 WORKDIR $HOME


### PR DESCRIPTION
*Issue #, if available:*

Current version causes an error 'Empty KUBERNETES_EXEC_INFO, defaulting to [client.authentication.k8s.io/v1alpha1](http://client.authentication.k8s.io/v1alpha1). This is likely a bug in your Kubernetes client. Please update your Kubernetes client.'

This is because kubernetes has depreciated v1alpha1

*Description of changes:*

Update Kubectl in Dockerfile to version 1.22.6

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
